### PR TITLE
feat :  Scroll to Top on Page Change

### DIFF
--- a/src/components/Pagination/PaginationButton.tsx
+++ b/src/components/Pagination/PaginationButton.tsx
@@ -29,15 +29,37 @@ const PaginationButton: FC<Props> = ({
     if (disable) return;
     if (!type) {
       onChange(+e.currentTarget.id);
-      window.scrollTo(0, 0);
+      if (window.innerWidth <= 430 && window.innerWidth >= 330) {
+        window.scrollTo({ top: 730, behavior: 'smooth' });
+    } else if (window.innerWidth <= 330) {
+        window.scrollTo({ top: 830, behavior: 'smooth' });
+    } else {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+    
       return;
     }
     if (type === 'prev') {
       onChange(currentPage - 1);
-      window.scrollTo(0, 0);
+      if (window.innerWidth <= 430 && window.innerWidth >= 330) {
+        window.scrollTo({ top: 730, behavior: 'smooth' });
+    } else if (window.innerWidth <= 330) {
+        window.scrollTo({ top: 830, behavior: 'smooth' });
+    } else {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+    
+
     } else if (type === 'next') {
       onChange(currentPage + 1);
-      window.scrollTo(0, 0);
+      if (window.innerWidth <= 430 && window.innerWidth >= 330) {
+        window.scrollTo({ top: 730, behavior: 'smooth' });
+    } else if (window.innerWidth <= 330) {
+        window.scrollTo({ top: 830, behavior: 'smooth' });
+    } else {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+    
     }
   };
 

--- a/src/components/Pagination/PaginationButton.tsx
+++ b/src/components/Pagination/PaginationButton.tsx
@@ -1,6 +1,18 @@
 import { Icon } from '@iconify-icon/react';
 import { useMemo, FC, MouseEvent } from 'react';
 
+
+// scroll to top while navigating through web-pages
+function scroll() {
+  if (window.innerWidth <= 430 && window.innerWidth >= 330) {
+    window.scrollTo({ top: 730, behavior: 'smooth' });
+} else if (window.innerWidth <= 330) {
+    window.scrollTo({ top: 830, behavior: 'smooth' });
+} else {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+}
+
 interface Props {
   item?: { label: number; isClickable?: boolean };
   type?: 'prev' | 'next';
@@ -29,37 +41,17 @@ const PaginationButton: FC<Props> = ({
     if (disable) return;
     if (!type) {
       onChange(+e.currentTarget.id);
-      if (window.innerWidth <= 430 && window.innerWidth >= 330) {
-        window.scrollTo({ top: 730, behavior: 'smooth' });
-    } else if (window.innerWidth <= 330) {
-        window.scrollTo({ top: 830, behavior: 'smooth' });
-    } else {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
+      scroll();
     
       return;
     }
     if (type === 'prev') {
       onChange(currentPage - 1);
-      if (window.innerWidth <= 430 && window.innerWidth >= 330) {
-        window.scrollTo({ top: 730, behavior: 'smooth' });
-    } else if (window.innerWidth <= 330) {
-        window.scrollTo({ top: 830, behavior: 'smooth' });
-    } else {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
-    
+      scroll();
 
     } else if (type === 'next') {
       onChange(currentPage + 1);
-      if (window.innerWidth <= 430 && window.innerWidth >= 330) {
-        window.scrollTo({ top: 730, behavior: 'smooth' });
-    } else if (window.innerWidth <= 330) {
-        window.scrollTo({ top: 830, behavior: 'smooth' });
-    } else {
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
-    
+      scroll();
     }
   };
 

--- a/src/components/Pagination/PaginationButton.tsx
+++ b/src/components/Pagination/PaginationButton.tsx
@@ -29,12 +29,15 @@ const PaginationButton: FC<Props> = ({
     if (disable) return;
     if (!type) {
       onChange(+e.currentTarget.id);
+      window.scrollTo(0, 0);
       return;
     }
     if (type === 'prev') {
       onChange(currentPage - 1);
+      window.scrollTo(0, 0);
     } else if (type === 'next') {
       onChange(currentPage + 1);
+      window.scrollTo(0, 0);
     }
   };
 


### PR DESCRIPTION
Previously, When navigating between pages in the easy-fix project, the page doesn't scroll to the top automatically. 
Now it had been added, when you navigate between pages, the window automatically show you the top of the web-page.

https://github.com/user-attachments/assets/81beac50-8b1c-4d24-ba7a-af2fa4c7fc4e

#84 