### PR TITLE
fix issue #105:first page shows one less than items per page

### DIFF
--- a/src/lib/utils/config.ts
+++ b/src/lib/utils/config.ts
@@ -6,7 +6,7 @@ import { SortingTag } from '@/models/SortingTag';
 export const BASE_URL = 'https://api.github.com';
 export const ISSUE_URL = `${BASE_URL}/search/issues`;
 export const INITIAL_LABELS = ['easy', 'first', 'good'];
-export const QUERIES = ['state:open'].join('+');
+export const QUERIES = ['state:open+is:issue+no:pr'].join('+');
 
 export const DEFAULT_LANGUAGE: Language = 'all';
 export const DEFAULT_ORDERING: Ordering = 'desc';


### PR DESCRIPTION
Problem:-
The pagination component displayed one less item on the first page than specified by 'items per page'.

Solution:
Before : previously api fetch list as per requirement like (5/10/15/20) then after filter out by checking that in url their is '/pull/' kind of thing or not which reduce number of list.
After : now we give ability to github(check issue is open but their is not pr ) do for ourself which help us to not filtering out later.

   