### PR TITLE
fix: mobile overflow caused by pagination buttons

### DIFF
--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -44,7 +44,7 @@ const Pagination: React.FC<Props> = ({ totalPages, currentPage, onChange }) => {
   if (totalPages <= 1) return null;
 
   return (
-    <div className='flex items-center justify-center gap-3 py-3 mb-5'>
+    <div className='flex items-center justify-center gap-3 py-3'>
       <PaginationButton
         onChange={onChange}
         currentPage={currentPage}

--- a/src/containers/Issues.tsx
+++ b/src/containers/Issues.tsx
@@ -80,7 +80,7 @@ const Issues = () => {
           )
         )}
       </div>
-      <div className="flex items-center justify-between py-3 mb-5">
+      <div className="flex flex-wrap items-center justify-between py-3 mb-5">
         <IssuesPerPageSelector
           value={itemsPerPage}
           onChange={handleItemsPerPageChange}


### PR DESCRIPTION

- Added flex-wrap to the container to allow items to wrap naturally on smaller screens (mobile and some tablet widths).
- Removed extra bottom margin (mb) on the Pagination component to ensure both the IssuesPerPageSelector and Pagination align neatly on the same line when space permits.
- Ensured layout remains consistent across viewports, maintaining spacing and alignment without overlapping or horizontal scrolling.
<img width="510" height="802" alt="image" src="https://github.com/user-attachments/assets/caf64dc2-f807-4663-905b-5b34a72594d6" />

<img width="962" height="802" alt="image" src="https://github.com/user-attachments/assets/9173a41c-22e5-4f31-9e33-2b0d28e21ef6" />


Fixes #120 
