### PR TITLE
feat: Search with multiple labels - Closes#128

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -6,16 +6,17 @@ interface Props {
   value: string;
   checked: boolean; // Added the missing 'checked' property
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  inputType?: 'radio' | 'checkbox';
 }
 
 // Updated the component definition to include the 'checked' property
-const Select: React.FC<Props> = ({ name, value, onChange, checked }) => {
+const Select: React.FC<Props> = ({ name, value, onChange, checked, inputType = 'radio' }) => {
   return (
     <>
       <input
         checked={checked}
         className='hidden peer'
-        type='radio'
+        type={inputType}
         name={name}
         onChange={onChange}
         id={toId(name)}

--- a/src/containers/Filter.tsx
+++ b/src/containers/Filter.tsx
@@ -8,14 +8,14 @@ import { sortedSortingTags } from '@/models/SortingTag';
 const Filter = () => {
   const {
     language,
-    label,
+    labelsSelected,
     labels,
     ordering,
     sortingTag,
     customLabel,
     customLabelHandler,
     languageChangeHandler,
-    labelsChangeHandler,
+    labelsToggleHandler,
     sortingTagClickHandler,
     setCustomLabel,
   } = useFilter();
@@ -43,9 +43,10 @@ const Filter = () => {
             <li key={toId(l)}>
               <Select
                 value={l}
-                checked={l === label}
+                checked={labelsSelected.includes(l)}
                 name={l}
-                onChange={labelsChangeHandler(l)}
+                onChange={labelsToggleHandler(l)}
+                inputType='checkbox'
               />
             </li>
           ))}

--- a/src/lib/hooks/use-filter.tsx
+++ b/src/lib/hooks/use-filter.tsx
@@ -8,28 +8,28 @@ import { FormEvent, createContext, useContext, useState } from 'react';
 type FilterContextType = {
   customLabel: string;
   language: Language;
-  label: string;
+  labelsSelected: Label[];
   ordering: Ordering;
   sortingTag: SortingTag;
   labels: Label[];
   customLabelHandler: (e: FormEvent) => void;
   setCustomLabel: (label: string) => void;
   languageChangeHandler: (payload: Language) => () => void;
-  labelsChangeHandler: (payload: Label) => () => void;
+  labelsToggleHandler: (payload: Label) => () => void;
   sortingTagClickHandler: (payload: SortingTag) => () => void;
 };
 
 const initialState: FilterContextType = {
   customLabel: '',
   language: 'all',
-  label: 'hacktoberfest',
+  labelsSelected: ['hacktoberfest'],
   ordering: 'asc',
   sortingTag: 'best-match',
   labels: sortedLabels,
   customLabelHandler: () => {},
   setCustomLabel: () => {},
   languageChangeHandler: () => () => {},
-  labelsChangeHandler: () => () => {},
+  labelsToggleHandler: () => () => {},
   sortingTagClickHandler: () => () => {},
 };
 
@@ -45,19 +45,19 @@ export default function FilterProvider({
 
   const customLabelHandler = (e: FormEvent) => {
     e.preventDefault();
-    setLabels([...labels, customLabel]);
-    labelsChangeHandler(customLabel as Label)();
+    setLabels([...labels, customLabel as Label]);
+    labelsToggleHandler(customLabel as Label)();
     setCustomLabel('');
   };
 
-  const { dispatch, language, ordering, sortingTag, label } = useUrlValues();
+  const { dispatch, language, ordering, sortingTag, labels: labelsSelected } = useUrlValues();
 
   const languageChangeHandler = (payload: Language) => {
     return () => dispatch({ type: 'update-language', payload });
   };
 
-  const labelsChangeHandler = (payload: Label) => {
-    return () => dispatch({ type: 'update-label', payload });
+  const labelsToggleHandler = (payload: Label) => {
+    return () => dispatch({ type: 'toggle-label', payload });
   };
 
   const sortingTagClickHandler = (payload: SortingTag) => {
@@ -68,14 +68,14 @@ export default function FilterProvider({
     <FilterContext.Provider
       value={{
         customLabel,
-        label,
+        labelsSelected,
         language,
         ordering,
         sortingTag,
         labels,
         customLabelHandler,
         languageChangeHandler,
-        labelsChangeHandler,
+        labelsToggleHandler,
         sortingTagClickHandler,
         setCustomLabel,
       }}

--- a/src/lib/hooks/useUrlValues/types.ts
+++ b/src/lib/hooks/useUrlValues/types.ts
@@ -9,7 +9,7 @@ export type State = {
   ordering: Ordering;
   page: number;
   sortingTag: SortingTag;
-  label: Label;
+  labels: Label[];
   itemsPerPage: number;
   url: string;
 };
@@ -24,9 +24,14 @@ type UpdateSortingTagAction = {
   payload: SortingTag;
 };
 
-type UpdateLabel = {
-  type: 'update-label';
+type ToggleLabelAction = {
+  type: 'toggle-label';
   payload: Label;
+};
+
+type SetLabelsAction = {
+  type: 'set-labels';
+  payload: Label[];
 };
 
 type UpdatePageAction = {
@@ -43,7 +48,8 @@ export type Action =
   | UpdateLanguageAction
   | UpdateSortingTagAction
   | UpdatePageAction
-  | UpdateLabel
+  | ToggleLabelAction
+  | SetLabelsAction
   | UpdateItemsPerPageAction;
 
 export const toggleOrdering = (


### PR DESCRIPTION
This feature has been enhanced to allow users to search for issues using multiple tags simultaneously, rather than being limited to a single tag or all tags at once. This improvement makes the search process more flexible and efficient, helping users discover a broader range of relevant issues. Supporting multiple tag selection ensures better filtering, improved accuracy, and a more user-friendly overall search experience.

<img width="1546" height="1015" alt="image" src="https://github.com/user-attachments/assets/1caedf05-e91b-4396-9709-e45291e09840" />

@vatsalsinghkv Please add the "Hacktoberfest" and "hacktoberfest-accepted" labels, review the changes and let me know if any changes are required, and proceed with merging the PR.